### PR TITLE
Set continue-on-error for checkov stage

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -129,7 +129,8 @@ jobs:
           quiet: true 
           framework: terraform_plan
           output_format: github_failed_only
-      
+        continue-on-error: true
+        
       - name: Infracost cost estimate
         id: cost-estimate
         run: |


### PR DESCRIPTION
- Set `continue-on-error: true` to prevent flagged checkov checks from failing entire job