### PR TITLE
Revert checkov changes to read from tf-plan

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -11,8 +11,6 @@ jobs:
   terraform-plan:
     name: "Plan"
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -1,0 +1,35 @@
+name: Static analysis
+
+on:
+  workflow_call:
+    secrets:
+      GITHUB_PAT:
+        description: "A GitHub PAT used to initialize private submodules"
+        required: true
+
+jobs:
+  terraform-plan:
+    name: "Plan"
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+          token: ${{ secrets.GITHUB_PAT }} # Needed for private submodules
+
+      # Allow private terraform modules to be initialized
+      - name: Setup git config
+        run: |
+          git config --global \
+            url."https://oauth2:${{ secrets.GITHUB_PAT }}@github.com".insteadOf https://github.com
+      
+      - name: Checkov static analysis
+        id: static-analysis
+        uses: bridgecrewio/checkov-action@master
+        with:
+          directory: .
+          framework: terraform
+          output_format: cli

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -15,10 +15,6 @@ on:
         description: "A YAML file containing cloud resource usage estimates for Infracost"
         required: false
         type: string
-      run_static_analysis:
-        description: "Set to true to run static analysis"
-        required: false
-        type: boolean
     secrets:
       AWS_ACCESS_KEY_ID:
         description: "The AWS Access Key ID for writing to the backend and managing resources."
@@ -121,16 +117,6 @@ jobs:
           cat terraform-${{ matrix.workspace }}.txt | tail -c 65000 > trunc_plan.txt
         continue-on-error: true
 
-      - name: Checkov static analysis
-        id: static-analysis
-        if: ${{ inputs.run_static_analysis == true }}
-        uses: bridgecrewio/checkov-action@master
-        with:
-          quiet: true 
-          framework: terraform_plan
-          output_format: github_failed_only
-        continue-on-error: true
-        
       - name: Infracost cost estimate
         id: cost-estimate
         run: |
@@ -170,8 +156,6 @@ jobs:
             const infracost_outcome = (${{ steps.cost-estimate.outputs.exitcode }} == 1) ?
               fs.readFileSync("./infracost-stderr.txt").toString() :
               fs.readFileSync("./infracost.md").toString();
-            const checkov_outcome = (${{ inputs.run_static_analysis }}) ?
-              `${{ env.CHECKOV_RESULTS }}` : "Static analysis was skipped";
 
             const output = `#### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
 
@@ -187,10 +171,7 @@ jobs:
 
             ### Infracost Breakdown 
             ${infracost_outcome}
-
-            ### Static Analysis
-            ${checkov_outcome}
-          
+                      
             *Pusher: @${{ github.actor }}, Workspace: \`${{ matrix.workspace }}\`*`;
 
             github.rest.issues.createComment({

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # github-action-terraform-aws
 
-Reusable terraform github workflows that deploy to AWS and provides cost estimates on PRs.
+Reusable terraform github workflows that deploy to AWS, provides cost estimates on PRs and static anaylsis using Checkov.
 
 <!-- BEGIN mktoc -->
 - [Usage](#usage)
   - [Prerequisites](#prerequisites)
   - [Fmt](#fmt)
+  - [Checkov](#checkov)
   - [Plan](#plan)
   - [Apply](#apply)
 <!-- END mktoc -->
@@ -37,6 +38,25 @@ jobs:
     uses: rewindio/github-action-terraform-aws/.github/workflows/fmt.yml@v1
 ```
 
+### Checkov
+
+Static analysis using Checkov can be performed by including `checkov.yml` into the workflow
+
+```yaml
+# .github/workflows/checkov.yml
+
+name: checkov
+concurrency: checkov
+on: pull_request
+
+jobs:
+  checkov-static-analysis:
+    name: "checkov"
+    uses: rewindio/github-action-terraform-aws/.github/workflows/checkov.yml@v1
+    secrets:
+      GITHUB_PAT: ${{ secrets.MY_GITHUB_PAT }}
+```
+
 ### Plan
 
 Plans are run when a pull request is open.
@@ -45,11 +65,6 @@ Within the `terraform-plan` workflow, Infracost is ran to provide a cost estimat
 
 The optional parameter `infracost_usage_file` is a YAML file that contains usage estimates for usage-based resources.
 
-#### Checkov
-
-Static analysis using Checkov can be performed by toggling the optional parameter `run_static_analysis`.
-
-To enable static analysis, set `run_static_analysis` to `true`.
 
 ```yaml
 # .github/workflows/tf-plan.yml
@@ -83,7 +98,6 @@ jobs:
       workspaces: ${{ needs.terraform-read-workspaces.outputs.staging_workspaces }}
       profile: staging
       infracost_usage_file: infracost.yml # OPTIONAL parameter
-      run_static_analysis: true # OPTIONAL paramter; defaults to false
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.MY_AWS_ACCESS_KEY_ID_STAGING }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MY_AWS_SECRET_ACCESS_KEY_STAGING }}
@@ -98,7 +112,6 @@ jobs:
       workspaces: ${{ needs.terraform-read-workspaces.outputs.production_workspaces }}
       profile: production
       infracost_usage_file: infracost.yml # OPTIONAL parameter
-      run_static_analysis: true # OPTIONAL paramter; defaults to false
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.MY_AWS_ACCESS_KEY_ID_STAGING }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MY_AWS_SECRET_ACCESS_KEY_STAGING }}


### PR DESCRIPTION
- de-coupled checkov from TF plan to get annotations in PR working
- updated readme.md

To get annotations in PRs, checkov needs to run on the directory and not a plan file. 

