### PR TITLE
Allow apply on main

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -118,14 +118,14 @@ jobs:
               }
             }
 
-      - name: Comment if not approved
-        if: steps.mergable.outputs.mergeable_state != 'clean' && steps.determine-command.outputs.do_apply == 'true' && github.event.issue.pull_request 
+      - name: Comment if not run
+        if: steps.determine-command.outcome == 'skipped'
         id: unmergable_comment
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
-            :rotating_light: You cannot apply until the PR is approved and ready to merge
+            :rotating_light: You cannot apply until the PR is both approved and ready to merge
           reactions: eyes
 
       - name: Checkout branch

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -11,6 +11,16 @@ on:
         description: "A JSON Array that contains list of all workspaces to apply."
         required: true
         type: string
+      terraform_dir:
+        description: "The path to the terraform files"
+        required: false
+        type: string
+        default: .
+      setup_script:
+        description: "Additional setup to be run before apply (i.e. export TF_VAR)"
+        required: false
+        type: string
+        default: .
     secrets:
       AWS_ACCESS_KEY_ID:
         description: "The AWS Access Key ID for writing to the backend and managing resources."
@@ -156,6 +166,7 @@ jobs:
 
       - name: Terraform Init
         id: init
+        working-directory: ${{ inputs.terraform_dir }}
         run: |
           # TODO: Allow for optional override
           backend_file=backend/${{ inputs.profile }}.tfvars
@@ -164,19 +175,21 @@ jobs:
 
       - name: Terraform Apply
         id: apply
+        working-directory: ${{ inputs.terraform_dir }}
         if: steps.mergable.outputs.mergeable_state == 'clean' && steps.determine-command.outputs.do_apply == 'true'
         run: |
           set -xo pipefail
+          ${{ inputs.setup_script }}
           terraform apply -no-color -var-file ${{ steps.init.outputs.backend_file }} -var-file ${{ steps.tfvars.outputs.tfvar_file }} -auto-approve |& tee terraform-${{ env.TF_WORKSPACE }}-apply-stdout.txt
 
       - name: Display terraform apply results
         uses: actions/github-script@v6
-        if: always() && steps.mergable.outputs.mergeable_state == 'clean' && steps.determine-command.outputs.do_apply == 'true'
+        if: always() && github.ref != 'refs/heads/main' && steps.mergable.outputs.mergeable_state == 'clean' && steps.determine-command.outputs.do_apply == 'true'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs");
-            const apply = fs.readFileSync("./terraform-${{ env.TF_WORKSPACE }}-apply-stdout.txt").toString();
+            const apply = fs.readFileSync("${{ inputs.terraform_dir }}/terraform-${{ env.TF_WORKSPACE }}-apply-stdout.txt").toString();
             const output = `#### Terraform Apply \`${{ steps.apply.outcome }}\`
             <details><summary>Show Apply</summary>
 

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -20,7 +20,7 @@ on:
         description: "Additional setup to be run before apply (i.e. export TF_VAR)"
         required: false
         type: string
-        default: .
+        default: ""
     secrets:
       AWS_ACCESS_KEY_ID:
         description: "The AWS Access Key ID for writing to the backend and managing resources."
@@ -60,14 +60,12 @@ jobs:
               --header 'content-type: application/json')
             mergeable_state=$(jq -r '.mergeable_state' <<< "$resp")
           fi
-          echo "The mergeable state is $mergeable_state"
           echo "::set-output name=mergeable_state::$mergeable_state"
 
       - name: Set varfile
         id: tfvars
         run: |
           # Construct tfvars pattern
-          # TODO: allow for optional override?
           echo "::set-output name=tfvar_file::tfvars/${{ inputs.profile }}/${{ matrix.workspace }}.tfvars"
 
       - name: Set terraform workspace
@@ -75,7 +73,7 @@ jobs:
 
      # This step is needed because a comment on a PR is is in the scope of an issue
       - name: Load PR Details
-        if: steps.mergable.outputs.mergeable_state == 'clean'
+        if: steps.mergable.outputs.mergeable_state == 'clean' && github.ref != 'refs/heads/main'
         id: load-pr
         run: |
           set -eu
@@ -85,11 +83,9 @@ jobs:
             --header 'content-type: application/json')
           sha=$(jq -r '.head.sha' <<< "$resp")
           echo "::set-output name=head_sha::$sha"
-          comments_url=$(jq -r '.comments_url' <<< "$resp")
-          echo "::set-output name=comments_url::$comments_url"
 
       - name: Determine Command
-        if: steps.mergable.outputs.mergeable_state == 'clean'
+        if: steps.mergable.outputs.mergeable_state == 'clean' && github.ref != 'refs/heads/main'
         id: determine-command
         uses: actions/github-script@v6
         env:
@@ -97,7 +93,6 @@ jobs:
         with:
           github-token: ${{github.token}}
           script: |
-            // console.log(context)
             const body = context.payload.comment.body.toLowerCase().trim()
             console.log("Detected PR comment: " + body)
             console.log("This job is for workspace " + process.env.TF_WORKSPACE)
@@ -124,7 +119,7 @@ jobs:
             }
 
       - name: Comment if not approved
-        if: steps.mergable.outputs.mergeable_state != 'clean' && steps.determine-command.outputs.do_apply == 'true'
+        if: steps.mergable.outputs.mergeable_state != 'clean' && steps.determine-command.outputs.do_apply == 'true' && github.ref != 'refs/heads/main'
         id: unmergable_comment
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -133,11 +128,19 @@ jobs:
             :rotating_light: You cannot apply until the PR is approved and ready to merge
           reactions: eyes
 
-      - name: Checkout
+      - name: Checkout branch
         uses: actions/checkout@v2
+        if: github.ref != 'refs/heads/main'
         with:
           submodules: 'true'
           ref: ${{ steps.load-pr.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_PAT }} # Needed for private submodules
+
+      - name: Checkout main
+        uses: actions/checkout@v2
+        if: github.ref == 'refs/heads/main'
+        with:
+          submodules: 'true'
           token: ${{ secrets.GITHUB_PAT }} # Needed for private submodules
 
       # Allow for private terraform modules to be initialized
@@ -168,7 +171,6 @@ jobs:
         id: init
         working-directory: ${{ inputs.terraform_dir }}
         run: |
-          # TODO: Allow for optional override
           backend_file=backend/${{ inputs.profile }}.tfvars
           echo "::set-output name=backend_file::$backend_file"
           terraform init -backend-config "$backend_file"
@@ -176,7 +178,7 @@ jobs:
       - name: Terraform Apply
         id: apply
         working-directory: ${{ inputs.terraform_dir }}
-        if: steps.mergable.outputs.mergeable_state == 'clean' && steps.determine-command.outputs.do_apply == 'true'
+        if: (steps.mergable.outputs.mergeable_state == 'clean' && steps.determine-command.outputs.do_apply == 'true') || github.ref == 'refs/heads/main'
         run: |
           set -xo pipefail
           ${{ inputs.setup_script }}

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -17,7 +17,7 @@ on:
         type: string
         default: .
       setup_script:
-        description: "Additional setup to be run before apply (i.e. export TF_VAR)"
+        description: "Additional setup to be run before apply (i.e. export TF_VAR_foo=bar)"
         required: false
         type: string
         default: ""
@@ -73,7 +73,7 @@ jobs:
 
      # This step is needed because a comment on a PR is is in the scope of an issue
       - name: Load PR Details
-        if: steps.mergable.outputs.mergeable_state == 'clean' && github.ref != 'refs/heads/main'
+        if: steps.mergable.outputs.mergeable_state == 'clean' && github.event.issue.pull_request 
         id: load-pr
         run: |
           set -eu
@@ -85,7 +85,7 @@ jobs:
           echo "::set-output name=head_sha::$sha"
 
       - name: Determine Command
-        if: steps.mergable.outputs.mergeable_state == 'clean' && github.ref != 'refs/heads/main'
+        if: steps.mergable.outputs.mergeable_state == 'clean' && github.event.issue.pull_request 
         id: determine-command
         uses: actions/github-script@v6
         env:
@@ -119,7 +119,7 @@ jobs:
             }
 
       - name: Comment if not approved
-        if: steps.mergable.outputs.mergeable_state != 'clean' && steps.determine-command.outputs.do_apply == 'true' && github.ref != 'refs/heads/main'
+        if: steps.mergable.outputs.mergeable_state != 'clean' && steps.determine-command.outputs.do_apply == 'true' && github.event.issue.pull_request 
         id: unmergable_comment
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -130,7 +130,7 @@ jobs:
 
       - name: Checkout branch
         uses: actions/checkout@v2
-        if: github.ref != 'refs/heads/main'
+        if: github.event.issue.pull_request 
         with:
           submodules: 'true'
           ref: ${{ steps.load-pr.outputs.head_sha }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Checkout main
         uses: actions/checkout@v2
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request' 
         with:
           submodules: 'true'
           token: ${{ secrets.GITHUB_PAT }} # Needed for private submodules
@@ -178,7 +178,7 @@ jobs:
       - name: Terraform Apply
         id: apply
         working-directory: ${{ inputs.terraform_dir }}
-        if: (steps.mergable.outputs.mergeable_state == 'clean' && steps.determine-command.outputs.do_apply == 'true') || github.ref == 'refs/heads/main'
+        if: (steps.mergable.outputs.mergeable_state == 'clean' && steps.determine-command.outputs.do_apply == 'true') || !github.event.issue.pull_request
         run: |
           set -xo pipefail
           ${{ inputs.setup_script }}
@@ -186,7 +186,7 @@ jobs:
 
       - name: Display terraform apply results
         uses: actions/github-script@v6
-        if: always() && github.ref != 'refs/heads/main' && steps.mergable.outputs.mergeable_state == 'clean' && steps.determine-command.outputs.do_apply == 'true'
+        if: always() && github.event.issue.pull_request && steps.mergable.outputs.mergeable_state == 'clean' && steps.determine-command.outputs.do_apply == 'true'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Some repos may want to have apply run on main.

This enables them to do so.

This is a non-breaking change that adds additional functionality.

It also allows an arbitrary setup script to be passed into the workflow before apply is executed.

For example:
```yaml
      setup_script: |
        export TF_VAR_app_image_reference=${{ needs.publish-staging.outputs.tag }}
```