### PR TITLE
Fix check if pull request

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Checkout main
         uses: actions/checkout@v2
-        if: github.event.issue.push
+        if: ${{ !github.event.issue.pull_request }}
         with:
           submodules: 'true'
           token: ${{ secrets.GITHUB_PAT }} # Needed for private submodules


### PR DESCRIPTION
It turns out:

`! !github.event.issue.pull_request` is not the same as `${{ !github.event.issue.pull_request }}`

Tested both cases.
