### PR TITLE
Add integration with Slack on tf-apply

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -31,6 +31,15 @@ on:
       GITHUB_PAT:
         description: "A GitHub PAT used to initialize private submodules"
         required: true
+      APPLY_FAILURES_SLACK_WEBHOOK_URL:
+        description: "The Slack webhook url that maps to a Slack channel. This channel will be notified after a failed apply."
+        required: false
+      APPLY_SUCCESS_SLACK_WEBHOOK_URL:
+        description: "The Slack webhook url that maps to a Slack channel. This channel will be notified after a successful apply."
+        required: false
+      LOOKUP_USER_EMAIL_SLACK_TOKEN:
+        description: "A token to look up users by email and message them directly. This requires the GitHub & Slack email to match, and the 'Keep my email addresses private' option disabled. No failures occur in other cases."
+        required: false
 
 jobs:
   terraform-apply:
@@ -211,6 +220,70 @@ jobs:
               repo: context.repo.repo,
               body: output
             })
+
+      - name: Set secrets
+        # Allows for conditionals on secrets without exposing them
+        # https://github.com/actions/runner/issues/520 
+        id: secrets
+        run: |
+          echo '::set-output name=APPLY_SUCCESS_SLACK_WEBHOOK_URL::${{secrets.APPLY_SUCCESS_SLACK_WEBHOOK_URL}}'
+          echo '::set-output name=APPLY_FAILURES_SLACK_WEBHOOK_URL::${{secrets.APPLY_FAILURES_SLACK_WEBHOOK_URL}}'
+          echo '::set-output name=LOOKUP_USER_EMAIL_SLACK_TOKEN::${{secrets.LOOKUP_USER_EMAIL_SLACK_TOKEN}}'
+
+      - name: Set commit title
+        # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+        continue-on-error: true
+        # We take the first line (%s) from the git log and then escape out any single quotes
+        # https://stackoverflow.com/a/24247870
+        run: echo COMMIT_MESSAGE=$(git log -n 1 --pretty=format:%s) >> $GITHUB_ENV
+
+      - name: Notify Slack on Success
+        uses: ravsamhq/notify-slack-action@v1
+        if: always() && ${{ steps.secrets.outputs.APPLY_SUCCESS_SLACK_WEBHOOK_URL != '' }}
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: '{emoji} <{run_url}|Apply> to ${{ matrix.workspace }} has {status_message}'
+          message_format: >
+            ${{ github.actor }} pushed <{commit_url}|${{ env.COMMIT_MESSAGE }}>
+          footer: '<{repo_url}|{repo}>'
+          notify_when: 'success'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.APPLY_SUCCESS_SLACK_WEBHOOK_URL }}
+
+      - name: Notify Slack on Failure
+        uses: ravsamhq/notify-slack-action@v1
+        if: always() && ${{ steps.secrets.outputs.APPLY_FAILURES_SLACK_WEBHOOK_URL != '' }}
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: '{emoji} <{run_url}|Apply> to ${{ matrix.workspace }} has {status_message}'
+          message_format: >
+            ${{ github.actor }} pushed <{commit_url}|${{ env.COMMIT_MESSAGE }}>
+          footer: '<{repo_url}|{repo}>'
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.APPLY_FAILURES_SLACK_WEBHOOK_URL }}
+
+      - name: Find Slack user
+        if: failure() && ${{ steps.secrets.outputs.LOOKUP_USER_EMAIL_SLACK_TOKEN != '' }}
+        id: find-slack-user
+        uses: scribd/find-slack-user-action@v1
+        with:
+          include-at-symbol: true
+          slack-token: ${{ secrets.LOOKUP_USER_EMAIL_SLACK_TOKEN }}
+
+      - name: Send a Slack DM to the user linking the failure
+        if: failure() && ${{ steps.secrets.outputs.LOOKUP_USER_EMAIL_SLACK_TOKEN != '' }}
+        uses: archive/github-actions-slack@v2.2.1
+        with:
+          slack-function: send-message
+          slack-bot-user-oauth-access-token: ${{ secrets.LOOKUP_USER_EMAIL_SLACK_TOKEN }}
+          slack-channel: "${{ steps.find-slack-user.outputs.username }}"
+          slack-text: |
+            <@${{ steps.find-slack-user.outputs.member-id }}>: <${{ env.RUN_URL }}|${{ env.COMMIT_MESSAGE }}> has failed.
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Cleanup AWS Credentials
         if: always()


### PR DESCRIPTION
- Allows for failures to optionally be sent to a channel
- Allows for successes to optionally be sent to a channel
- Allows for optional send-a-DM to committer on failures