### PR TITLE
bump to v2

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -178,7 +178,7 @@ jobs:
         run: echo "::set-output name=terraform-version::$(cat ${{ inputs.terraform_dir }}/.terraform-version)"
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ steps.set-terraform-version.outputs.terraform-version}}
           terraform_wrapper: false

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -16,7 +16,7 @@ jobs:
         run: echo "::set-output name=terraform-version::$(cat .terraform-version)"
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ steps.set-terraform-version.outputs.terraform-version}}
           terraform_wrapper: false

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -86,7 +86,7 @@ jobs:
         run: echo TF_WORKSPACE="${{ matrix.workspace }}" >> $GITHUB_ENV
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ steps.set-terraform-version.outputs.terraform-version}}
           terraform_wrapper: false


### PR DESCRIPTION
resolve https://github.com/rewindio/rewind-app-ecs/runs/6358696515?check_suite_focus=true

```
Run hashicorp/setup-terraform@v1
  with:
    terraform_version: 1.2.0-rc1
    terraform_wrapper: false
    cli_config_credentials_hostname: app.terraform.io
  env:
    AWS_SHARED_CREDENTIALS_FILE: /tmp/ac
    AWS_PROFILE: staging
    GITHUB_TOKEN: ***
    TF_WORKSPACE: st-ecs-rewind-app_us-east-1
(node:13872) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
Error: Error: Request failed with status code 404
Error: Request failed with status code 404
```